### PR TITLE
Fix test for ssh key to allow new comment format

### DIFF
--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -156,8 +156,8 @@ describe 'accounts::user define', unless: UNSUPPORTED_PLATFORMS.include?(fact('o
       it('has authorized_key - vagrant', unless: default['platform'].match(%r{solaris-10})) {
         is_expected.to have_authorized_key "ssh-rsa #{test_key} vagrant"
       }
-      it('has authorized_key - vagrant2', unless: default['platform'].match(%r{solaris-10})) {
-        is_expected.to have_authorized_key "from=\"myhost.example.com,192.168.1.1\" ssh-rsa #{test_key} vagrant2"
+      it('has authorized_key - hunner_ssh-rsa_vagrant2', unless: default['platform'].match(%r{solaris-10})) {
+        is_expected.to have_authorized_key "from=\"myhost.example.com,192.168.1.1\" ssh-rsa #{test_key} hunner_ssh-rsa_vagrant2"
       }
     end
     describe file('/test/hunner') do


### PR DESCRIPTION
This might fix the failing test at https://github.com/puppetlabs/puppetlabs-accounts/pull/130